### PR TITLE
Fix pack solution task for later versions of 'pac'

### DIFF
--- a/src/generators/app/templates/source/build/Build.cs
+++ b/src/generators/app/templates/source/build/Build.cs
@@ -119,7 +119,7 @@ class Build : NukeBuild
 
            var metadataFolder = SolutionDirectory / "Extract";
            var mappingFilePath = SolutionDirectory / "ExtractMappingFile.xml";
-           Pac($"solution unpack -z {unmanagedSolutionPath} -f { metadataFolder } -p Both  -ad Yes -m { mappingFilePath }");
+           Pac($"solution unpack -z {unmanagedSolutionPath} -f { metadataFolder } -p Both  -ad true -m { mappingFilePath }");
 
            DeleteDirectory(outputDirectory);
        });


### PR DESCRIPTION


## Purpose
Pack solution task is not working. Fix it since Microsoft have changed the pac --allowDelete to true, instead of false, without this fix the follwing error is given:

```
Microsoft PowerPlatform CLI
Version: 1.13.4+g79187cf

Error: The value passed to --allowDelete is not valid. If no value is passed, the argument will default to true. Values: true, false.

Usage: pac solution pack --zipfile [--folder] [--packagetype] [--log] [--errorlevel] [--singleComponent] [--allowDelete] [--allowWrite] [--clobber] [--map] [--sourceLoc] [--localize] [--useLcid] [--useUnmanagedFileForMissingManaged] [--disablePluginRemap]
```

## Approach
Updates the parameter to match modern versions of pac.exe

## TODOs
- [X] Documentation updated (if required)
- [X] Build and tests successful
