### PR TITLE
feat: update sarif ado extension

### DIFF
--- a/src/generators/azuredevops/definitions/extensions.json
+++ b/src/generators/azuredevops/definitions/extensions.json
@@ -5,7 +5,7 @@
   },
   {
     "publisher": "sariftools",
-    "name": "sarif-viewer-build-tab"
+    "name": "scans"
   },
   {
     "publisher": "gittools",


### PR DESCRIPTION
`sarif-viewer-build-tab` is not deprecated so replacing it with `scans` by the same publisher.

Resolves #69.

## TODOs
- [x] Documentation updated (if required)
- [x] Build and tests successful
