### PR TITLE
Update RepoGenerator.ts

### DIFF
--- a/src/generators/azuredevops/generator/RepoGenerator.ts
+++ b/src/generators/azuredevops/generator/RepoGenerator.ts
@@ -40,7 +40,7 @@ export default class RepoGenerator implements IGenerator<GitRepository> {
       throw new Error('An error occurred while creating repository.');
     }
 
-    const orgName = repo.remoteUrl!.split('/')[2].split('.')[0];
+    const orgName = repo.remoteUrl!.split('/')[3].split('.')[0];
     const repoUrl = `https://${orgName}:${adoToken}@dev.azure.com/${orgName}/${encodeURIComponent(projectName)}/_git/${repoName}`;
 
     await this.pushRepo(repoLocation, repoUrl);


### PR DESCRIPTION
Updated line to fetch orgName which causes issue while  creating repourl

## Purpose
OrgName variable was set wrong as part of split function

## Approach
picks the third element to get actual orgName which is used to form repoUrl in next step

## TODOs
- [ ] Documentation updated (if required)
- [x] Build and tests successful
