### PR TITLE
Bug84 pushing initialized repo fails

### DIFF
--- a/src/generators/azuredevops/generator/RepoGenerator.ts
+++ b/src/generators/azuredevops/generator/RepoGenerator.ts
@@ -40,14 +40,10 @@ export default class RepoGenerator implements IGenerator<GitRepository> {
       throw new Error('An error occurred while creating repository.');
     }
 
-    var orgName : string = repo.remoteUrl!.split('/')[2].split('.')[0];
-    var repoUrl : string = "";
-    if(orgName != "dev")
-      repoUrl = `https://${orgName}:${adoToken}@dev.azure.com/${orgName}/${encodeURIComponent(projectName)}/_git/${repoName}`;
-    else
-      orgName = repo.remoteUrl!.split('/')[3].split('.')[0];
-      repoUrl = `https://${orgName}:${adoToken}@dev.azure.com/${orgName}/${encodeURIComponent(projectName)}/_git/${repoName}`;
-   
+    const orgName : string = repo.remoteUrl!.startsWith('https://dev.azure.com/')
+        ? repo.remoteUrl!.split('/')[3] // for https://dev.azure.com/{orgname}/
+        : repo.remoteUrl!.split('/')[2].split('.')[0]; // for https://{orgname}.visualstudio.com/
+    const repoUrl = `https://${orgName}:${adoToken}@dev.azure.com/${orgName}/${encodeURIComponent(projectName)}/_git/${repoName}`;   
     await this.pushRepo(repoLocation, repoUrl);
 
     return repo;

--- a/src/generators/azuredevops/generator/RepoGenerator.ts
+++ b/src/generators/azuredevops/generator/RepoGenerator.ts
@@ -40,7 +40,7 @@ export default class RepoGenerator implements IGenerator<GitRepository> {
       throw new Error('An error occurred while creating repository.');
     }
 
-    const orgName = repo.remoteUrl!.split('/')[2].split('.')[0];
+    const orgName = repo.remoteUrl!.split('/')[3].split('.')[0];
     const repoUrl = `https://${orgName}:${adoToken}@dev.azure.com/${orgName}/${encodeURIComponent(projectName)}/_git/${repoName}`;
 
     await this.pushRepo(repoLocation, repoUrl);

--- a/src/generators/azuredevops/generator/RepoGenerator.ts
+++ b/src/generators/azuredevops/generator/RepoGenerator.ts
@@ -41,9 +41,9 @@ export default class RepoGenerator implements IGenerator<GitRepository> {
     }
 
     const orgName : string = repo.remoteUrl!.startsWith('https://dev.azure.com/')
-        ? repo.remoteUrl!.split('/')[3] // for https://dev.azure.com/{orgname}/
-        : repo.remoteUrl!.split('/')[2].split('.')[0]; // for https://{orgname}.visualstudio.com/
-    const repoUrl = `https://${orgName}:${adoToken}@dev.azure.com/${orgName}/${encodeURIComponent(projectName)}/_git/${repoName}`;   
+      ? repo.remoteUrl!.split('/')[3] // for https://dev.azure.com/{orgname}/
+      : repo.remoteUrl!.split('/')[2].split('.')[0]; // for https://{orgname}.visualstudio.com/
+    const repoUrl = `https://${orgName}:${adoToken}@dev.azure.com/${orgName}/${encodeURIComponent(projectName)}/_git/${repoName}`;
     await this.pushRepo(repoLocation, repoUrl);
 
     return repo;

--- a/src/generators/azuredevops/generator/RepoGenerator.ts
+++ b/src/generators/azuredevops/generator/RepoGenerator.ts
@@ -40,9 +40,14 @@ export default class RepoGenerator implements IGenerator<GitRepository> {
       throw new Error('An error occurred while creating repository.');
     }
 
-    const orgName = repo.remoteUrl!.split('/')[3].split('.')[0];
-    const repoUrl = `https://${orgName}:${adoToken}@dev.azure.com/${orgName}/${encodeURIComponent(projectName)}/_git/${repoName}`;
-
+    var orgName : string = repo.remoteUrl!.split('/')[2].split('.')[0];
+    var repoUrl : string = "";
+    if(orgName != "dev")
+      repoUrl = `https://${orgName}:${adoToken}@dev.azure.com/${orgName}/${encodeURIComponent(projectName)}/_git/${repoName}`;
+    else
+      orgName = repo.remoteUrl!.split('/')[3].split('.')[0];
+      repoUrl = `https://${orgName}:${adoToken}@dev.azure.com/${orgName}/${encodeURIComponent(projectName)}/_git/${repoName}`;
+   
     await this.pushRepo(repoLocation, repoUrl);
 
     return repo;


### PR DESCRIPTION
## Purpose
To add support to navigate created repo using legacy and new azure devops url syntax as per 
https://docs.microsoft.com/en-us/azure/devops/extend/develop/work-with-urls?view=azure-devops&tabs=http

## Approach
Added support to navigate newly created repo in azure devops generator using both url type new and legacy 

## TODOs
- [ ] Documentation updated (if required)
- [ ] Build and tests successful
