### PR TITLE
fix: pack solution arguments for vs code cmd

### DIFF
--- a/__tests__/sample-with-solution/build/Build.cs
+++ b/__tests__/sample-with-solution/build/Build.cs
@@ -130,7 +130,7 @@ class Build : NukeBuild
             var metadataFolder = SolutionDirectory / "Extract";
             var mappingFilePath = SolutionDirectory / "ExtractMappingFile.xml";
             var buildConfiguration  = SolutionType == SolutionType.Unmanaged ? Configuration.Debug : Configuration.Release;
-            Pac($"solution pack -z \"{SolutionDirectory / "bin" / buildConfiguration / $"{DataverseSolution}.zip"}\" -f {metadataFolder} -p {SolutionType} -ad Yes -m { mappingFilePath }");
+            Pac($"solution pack -z \"{SolutionDirectory / "bin" / buildConfiguration / $"{DataverseSolution}.zip"}\" -f {metadataFolder} -p {SolutionType} -ad true -m { mappingFilePath }");
         });
 
     Target PrepareDevelopmentEnvironment => _ => _

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "copy-scripts-template": "copyfiles -a -u 4 \"src/generators/scripts/templates/**/*\" \"generators/scripts/templates\" -V",
     "copy-data-template": "copyfiles -a -u 4 \"src/generators/data/templates/**/*\" \"generators/data/templates\" -V",
     "copy-powerbi-template": "copyfiles -a -u 4 \"src/generators/powerbi/templates/**/*\" \"generators/powerbi/templates\" -V",
-    "clean-debug": "npx rimraf debug",
+    "clean-debug": "npx rimraf debug && mkdir debug",
     "lint": "eslint .eslintrc.js ./src ./__tests__/"
   }
 }

--- a/src/generators/app/templates/source/build/Build.cs
+++ b/src/generators/app/templates/source/build/Build.cs
@@ -130,7 +130,7 @@ class Build : NukeBuild
             var metadataFolder = SolutionDirectory / "Extract";
             var mappingFilePath = SolutionDirectory / "ExtractMappingFile.xml";
             var buildConfiguration  = SolutionType == SolutionType.Unmanaged ? Configuration.Debug : Configuration.Release;
-            Pac($"solution pack -z \"{SolutionDirectory / "bin" / buildConfiguration / $"{DataverseSolution}.zip"}\" -f {metadataFolder} -p {SolutionType} -ad Yes -m { mappingFilePath }");
+            Pac($"solution pack -z \"{SolutionDirectory / "bin" / buildConfiguration / $"{DataverseSolution}.zip"}\" -f {metadataFolder} -p {SolutionType} -ad true -m { mappingFilePath }");
         });
 
     Target PrepareDevelopmentEnvironment => _ => _


### PR DESCRIPTION
## Purpose
_Describe the problem or feature in addition to a link to the issue(s)._
closes #88 
Also fix for debugging project (clean-debug) as was not re-creating debug folder for testing changes
## Approach
changes the vscode task for packing solutions pack arg -ad (allowdelete) to 'true' as 'yes' is no longer accepted and erroring 
## TODOs
- [ ] Documentation updated (if required)
- [ ] Build and tests successful
