### PR TITLE
Fix #102: Update targetframework to net7.0

### DIFF
--- a/__tests__/sample-with-solution/.vscode/launch.json
+++ b/__tests__/sample-with-solution/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/build/bin/Debug/netcoreapp3.1/_build.dll",
+            "program": "${workspaceFolder}/build/bin/Debug/_build.dll",
             "args": [],
             "cwd": "${workspaceFolder}/build",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console

--- a/__tests__/sample-with-solution/build/_build.csproj
+++ b/__tests__/sample-with-solution/build/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>

--- a/src/generators/app/templates/source/.vscode/launch.json
+++ b/src/generators/app/templates/source/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/build/bin/Debug/netcoreapp3.1/_build.dll",
+            "program": "${workspaceFolder}/build/bin/Debug/_build.dll",
             "args": [],
             "cwd": "${workspaceFolder}/build",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console

--- a/src/generators/app/templates/source/build/_build.csproj
+++ b/src/generators/app/templates/source/build/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>


### PR DESCRIPTION
## Purpose
The Build project that is included in the template files is targeting the old netcoreapp3.1 framework. The framework is no longer installed by default on the 'windows-latest' image, and therefore the pipeline fails.

## Approach
Updates targetframework to net7.0.

## TODOs
- [x] Documentation updated (if required)
- [x] Build and tests successful
