### PR TITLE
Update release.json change versions numbers on Extensions

### DIFF
--- a/src/generators/azuredevops/definitions/release/release.json
+++ b/src/generators/azuredevops/definitions/release/release.json
@@ -63,7 +63,7 @@
             {
               "environment": {},
               "taskId": "8015465b-f367-4ec4-8215-8edf682574d3",
-              "version": "0.*",
+              "version": "2.*",
               "name": "Power Platform Tool Installer ",
               "refName": "",
               "enabled": true,
@@ -77,7 +77,7 @@
             {
               "environment": {},
               "taskId": "6eba22e9-9666-4241-8664-3d96354449c3",
-              "version": "0.*",
+              "version": "2.*",
               "name": "Deploy Package",
               "refName": "",
               "enabled": true,


### PR DESCRIPTION
Changes version number to 2 on:

- Power Platform Tool Installer
- Deploy Package

## Purpose
Resolves bug ticket [106](https://github.com/Capgemini/powerapps-project-template/issues/106)

## Approach
Minor changes to version numbers in required extensions of release pipeline

